### PR TITLE
修复获取click范围在缩放和旋转的情况下不正确的问题。

### DIFF
--- a/FairyGUI-starling/src/fairygui/GObject.as
+++ b/FairyGUI-starling/src/fairygui/GObject.as
@@ -1136,7 +1136,6 @@ package fairygui
 		private var _buttonStatus:int;
 		private var _rollOver:Boolean;
 		private var _touchDownPoint:Point;
-		private static var sHelpRect:Rectangle = new Rectangle();
 		private static var sHelperPoint:Point = new Point();
 		private static const MTOUCH_EVENTS:Array = 
 			[GTouchEvent.BEGIN, GTouchEvent.DRAG, GTouchEvent.END, GTouchEvent.CLICK,
@@ -1268,8 +1267,8 @@ package fairygui
 					_lastClick = now;
 				
 				
-				var isWithinBounds:Boolean = localToGlobalRect(0, 0, width, height, sHelpRect).contains(touch.globalX, touch.globalY);
-				
+				globalToLocal(touch.globalX, touch.globalY, sHelperPoint);
+				var isWithinBounds:Boolean = sHelperPoint.x >= 0 && sHelperPoint.x <= width && sHelperPoint.y >= 0 && sHelperPoint.y <= height;
 				if (isWithinBounds)
 				{
 					var devt:GTouchEvent = new GTouchEvent(GTouchEvent.CLICK);


### PR DESCRIPTION
修复获取click范围在缩放和旋转的情况下不正确的问题。
